### PR TITLE
Add use keyword to grammar/spec

### DIFF
--- a/grammars/janet.cson
+++ b/grammars/janet.cson
@@ -123,7 +123,7 @@ repository:
     keyfn:
         patterns: [
             {
-                match: "(?<=(\\s|\\(|\\[|\\{))(asm|break|(def[a-z\\-]*)|(var[a-z\\-]*)|fn|quote|quasiquote|unquote|struct|(import[\*]?)|yield)(?=(\\s|\\)|\\]|\\}))"
+                match: "(?<=(\\s|\\(|\\[|\\{))(asm|break|(def[a-z\\-]*)|(var[a-z\\-]*)|fn|quote|quasiquote|unquote|struct|(import[\*]?)|(use[\*]?)|yield)(?=(\\s|\\)|\\]|\\}))"
                 name: "keyword.control.janet"
             }
             {

--- a/spec/janet-spec.coffee
+++ b/spec/janet-spec.coffee
@@ -100,7 +100,7 @@
     expect(tokens[5]).toEqual value: ":bar", scopes: ["source.janet", "meta.expression.janet", "meta.definition.global.janet", "constant.keyword.janet"]
 
   it "tokenizes keyfns (keyword control)", ->
-    keyfns = ["import", "require", "def", "def-", "defglobal", "var", "varglobal", "defn", "defn-", "defmacro", "defmacro-"]
+    keyfns = ["import", "require", "def", "def-", "defglobal", "var", "varglobal", "defn", "defn-", "defmacro", "defmacro-" "use"]
 
     for keyfn in keyfns
       {tokens} = grammar.tokenizeLine "(#{keyfn})"


### PR DESCRIPTION
This just adds "use" as a keyword

`(use lib)` == `(import lib :prefix "")`

I occasionally use `use` and wanted it to show up the same color as `import`

