### PR TITLE
Get comments working again

### DIFF
--- a/settings/language-janet.cson
+++ b/settings/language-janet.cson
@@ -1,7 +1,7 @@
-'.source.carp':
+'.source.janet':
   'editor':
     'autoIndentOnPaste': false
-    'commentStart': '; '
+    'commentStart': '#'
     'tabLength': 4
     'softTabs': true
     'preferredLineLength': 80


### PR DESCRIPTION
### Description of the Change

I'm not sure how long this was in there, but it was using `source.carp` for the initial settings instead of `source.janet`

Comment toggles also weren't working

- Before: `Cmd + /` => `/* */`
- Now: `Cmd + /` => `#` 

### Benefits

Everyone gets working janet comment toggling without any configuration

### Possible Drawbacks

This may cause changes if people have overridden the language-janet defaults already.

### Applicable Issues

None
